### PR TITLE
Add a Twitter timeline page

### DIFF
--- a/twitter.html
+++ b/twitter.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>Twitter feed - #CashlessConsumer</title>
+	<meta name="description" content="Twitter feed for #CashlessConsumer">
+	<meta name="author" content="Srikanth L">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<link rel="apple-touch-icon-precomposed" sizes="144x144" href="img/touch/apple-touch-icon-144x144-precomposed.png">
+	<link rel="apple-touch-icon-precomposed" sizes="114x114" href="img/touch/apple-touch-icon-114x114-precomposed.png">
+	<link rel="apple-touch-icon-precomposed" sizes="72x72" href="img/touch/apple-touch-icon-72x72-precomposed.png">
+	<link rel="apple-touch-icon-precomposed" href="img/touch/apple-touch-icon-57x57-precomposed.png">
+	<link rel="shortcut icon" sizes="196x196" href="img/touch/touch-icon-196x196.png">
+	<link rel="shortcut icon" href="img/touch/apple-touch-icon.png">
+	<meta name="msapplication-TileImage" content="img/touch/apple-touch-icon-144x144-precomposed.png">
+	<meta name="msapplication-TileColor" content="#222222">
+
+	<!-- FONT –––––––––––––––––––––––––––––––––––––––––––––––––– -->
+	<link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet"/>
+	<link rel="stylesheet" href="https://opensource.keycdn.com/fontawesome/4.6.3/font-awesome.min.css" integrity="sha384-Wrgq82RsEean5tP3NK3zWAemiNEXofJsTwTyHmNb/iL3dP/sZJ4+7sOld1uqYJtE" crossorigin="anonymous">
+
+	<!-- CSS –––––––––––––––––––––––––––––––––––––––––––––––––– -->
+	<link rel="stylesheet" href="css/bootstrap.min.css"/>
+	<link rel="stylesheet" href="css/style.css"/>
+	<link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/jquery.jssocials/1.3.1/jssocials.css" />
+	<link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/jquery.jssocials/1.3.1/jssocials-theme-flat.css" />
+
+	<!-- Favicon –––––––––––––––––––––––––––––––––––––––––––––––––– -->
+	<link rel="icon" type="image/png" href="images/favicon.png">
+
+</head>
+<body>
+	<header>
+		<nav class="navbar navbar-default">
+			<div class="container">
+				<div class="navbar-header">
+					<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#cc-navbar-collapse" aria-expanded="false">
+						<span class="sr-only">Toggle navigation</span>
+						<span class="icon-bar"></span>
+						<span class="icon-bar"></span>
+						<span class="icon-bar"></span>
+					</button>
+					<a href="index.html" class="navbar-brand">#CashlessConsumer</a>
+				</div>
+				<div class="collapse navbar-collapse"  id="cc-navbar-collapse">
+					<ul class="nav navbar-nav navbar-left">
+						<li><a href="./index.html">Home</a></li>
+						<li><a href="./upi-setup.html">How to Install</a></li>
+						<li><a href="./applist.html">UPI Apps</a></li>
+						<li><a href="./qrcode.html">Get QR Code</a></li>
+						<li><a href="./about.html">About</a></li>
+						<li><a href="./askus.html">Ask Us</a></li>
+					</ul>
+					<ul class="nav navbar-nav navbar-right">
+						<li><a href="#"><select id="lang" onchange="updateText()">
+							<option value="en">English</option>
+							<option value="ta">தமிழ்</option>
+							<option value="kn">ಕನ್ನಡ</option>
+						</select></a></li>
+					</ul>
+				</div>
+			</div>
+		</nav>
+	</header>
+	<article>
+		<div class="title-banner">
+			<div class="container">
+				<div class="row">
+					<div class="col-md-12">
+						<h1>#CashlessConsumer Twitter feed</h1>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="container content">
+			<div class="row">
+				<div class="col-md-12">
+
+					<!-- Twitter widget code -->
+					<a class="twitter-timeline" data-dnt="true" href="https://twitter.com/hashtag/CashlessConsumer" data-widget-id="811107706362695680">#CashlessConsumer Tweets</a>
+					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+					
+				</div>
+			</div>
+			<center><div id="sharesocial"/></center>
+
+		</div> <!-- end .container -->
+	</article>
+	<footer>
+		<div class="container">
+			<p class="copyright"><span data-i18n="upiqrc-footer">#CashlessConsumer Initiative. Licensed under </span><a href="https://creativecommons.org/licenses/by-sa/4.0/"><span data-i18n="upiqrc-license">CC-BY-SA 4.0</span></a> - <a href="http://github.com/srikanthlogic/CashlessConsumer"><span data-i18n="upiqrc-codelink">Code</span></a></p>
+		</div>
+	</footer>
+<!-- End Document –––––––––––––––––––––––––––––––––––––––––––––––––– -->
+
+	<script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+	<script src="js/bootstrap.min.js"></script>
+	<script type="text/javascript" src="https://cdn.jsdelivr.net/jquery.jssocials/1.3.1/jssocials.min.js"></script>
+	<script>
+		$("#sharesocial").jsSocials({
+			url: "https://srikanthlogic.github.io/CashlessConsumer/askus.html",
+			text: "Ask us any question on #UPI and we will try to get back with answer | #CashlessConsumer",
+			showCount: "inside",
+			showLabel: false,
+			shareIn: "popup",
+			shares: ["email", "twitter", "facebook", "whatsapp", "googleplus"]
+	  });
+
+	</script>
+	<script src="js/main.js"></script>
+		<script>
+	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+	  ga('create', 'UA-83520638-1', 'auto');
+	  ga('send', 'pageview');
+
+	</script>
+
+
+</body>
+</html>

--- a/twitter.html
+++ b/twitter.html
@@ -78,7 +78,7 @@
 				<div class="col-md-12">
 
 					<!-- Twitter widget code -->
-					<a class="twitter-timeline" data-dnt="true" href="https://twitter.com/hashtag/CashlessConsumer" data-widget-id="811107706362695680">#CashlessConsumer Tweets</a>
+					<a class="twitter-timeline" data-dnt="true" href="https://twitter.com/hashtag/CashlessConsumer" data-widget-id="811107706362695680" data-width="640" data-chrome="noheader">#CashlessConsumer Tweets</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 					
 				</div>


### PR DESCRIPTION
For #16, a basic version of Twitter timeline for the #CashlessConsumer hashtag. Here is how it looks:

![cashlessconsumer-twitter-timeline-page](https://cloud.githubusercontent.com/assets/6792988/21348470/543611aa-c6d3-11e6-90ea-ffc8f4b0581e.png)

More sexy layouts are possible with a timeline created using TweetDeck.


